### PR TITLE
Make task list contain unique entries

### DIFF
--- a/src/main/java/bot/exceptions/DuplicateTaskException.java
+++ b/src/main/java/bot/exceptions/DuplicateTaskException.java
@@ -1,0 +1,22 @@
+package bot.exceptions;
+
+/**
+ * Exception for when duplicate tasks are encountered and are not supposed to exist.
+ */
+public class DuplicateTaskException extends InvalidTaskException {
+    /**
+     * Constructor with default message.
+     */
+    public DuplicateTaskException() {
+        super("Task already exists!");
+    }
+
+    /**
+     * Constructor with variable message.
+     *
+     * @param msg Message to be displayed when getMessage is called.
+     */
+    public DuplicateTaskException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/bot/utils/TaskList.java
+++ b/src/main/java/bot/utils/TaskList.java
@@ -5,18 +5,19 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import bot.exceptions.DuplicateTaskException;
 import bot.exceptions.InvalidIndexException;
 import bot.utils.tasks.Task;
 
 /**
- * Bot.Task list abstraction. Functions like an arraylist but may not contain one.
+ * Task list abstraction. Functions like an arraylist but may not contain one. Does not accept duplicates.
  * Index starts at 1.
  */
 public class TaskList {
     /**
      * Data structure to hold list.
      */
-    private List<Task> list = new ArrayList<>();
+    private final List<Task> tasks = new ArrayList<>();
 
     /**
      * Default constructor. To be used when an empty list is needed.
@@ -30,16 +31,26 @@ public class TaskList {
      * @param list List of Task objects.
      */
     public TaskList(Collection<Task> list) {
-        this.list.addAll(list);
+        for (Task task : list) {
+            try {
+                add(task);
+            } catch (DuplicateTaskException exception) {
+                // We ignore duplicates because our task list should have unique items.
+            }
+        }
     }
 
     /**
      * Adds a task to the end of the list.
      *
-     * @param task Bot.Task to add.
+     * @param task Task to add.
+     * @throws DuplicateTaskException If the list already contains the task.
      */
-    public void add(Task task) {
-        this.list.add(task);
+    public void add(Task task) throws DuplicateTaskException {
+        if (tasks.contains(task)) {
+            throw new DuplicateTaskException();
+        }
+        tasks.add(task);
     }
 
     /**
@@ -49,7 +60,7 @@ public class TaskList {
      * @return Bot.Task object.
      */
     public Task get(int index) {
-        return this.list.get(index - 1);
+        return tasks.get(index - 1);
     }
 
     /**
@@ -60,10 +71,10 @@ public class TaskList {
      * @throws InvalidIndexException If index is out of range.
      */
     public Task remove(int index) throws InvalidIndexException {
-        if (index < 1 || index > list.size()) {
+        if (index < 1 || index > tasks.size()) {
             throw new InvalidIndexException();
         }
-        return this.list.remove(index - 1);
+        return tasks.remove(index - 1);
     }
 
     /**
@@ -72,7 +83,7 @@ public class TaskList {
      * @return Length of list.
      */
     public int size() {
-        return this.list.size();
+        return tasks.size();
     }
 
     /**
@@ -81,7 +92,7 @@ public class TaskList {
      * @return Iterator of Task objects.
      */
     public Iterator<Task> getIterator() {
-        return this.list.iterator();
+        return tasks.iterator();
     }
 
     /**
@@ -91,10 +102,10 @@ public class TaskList {
      * @throws InvalidIndexException If index is out of range.
      */
     public void mark(int index) throws InvalidIndexException {
-        if (index < 1 || index > list.size()) {
+        if (index < 1 || index > tasks.size()) {
             throw new InvalidIndexException();
         }
-        this.list.get(index - 1).mark();
+        tasks.get(index - 1).mark();
     }
 
     /**
@@ -104,10 +115,10 @@ public class TaskList {
      * @throws InvalidIndexException If index is out of range.
      */
     public void unmark(int index) throws InvalidIndexException {
-        if (index < 1 || index > list.size()) {
+        if (index < 1 || index > tasks.size()) {
             throw new InvalidIndexException();
         }
-        this.list.get(index - 1).unmark();
+        tasks.get(index - 1).unmark();
     }
 
     /**
@@ -117,12 +128,16 @@ public class TaskList {
      * @return TaskList of tasks.
      */
     public TaskList findAll(String str) {
-        Iterator<Task> iter = list.iterator();
+        Iterator<Task> iter = tasks.iterator();
         TaskList out = new TaskList();
         while (iter.hasNext()) {
             Task task = iter.next();
             if (task.getName().toLowerCase().contains(str.toLowerCase())) {
-                out.add(task);
+                try {
+                    out.add(task);
+                } catch (DuplicateTaskException exception) {
+                    // We ignore duplicate tasks because there's no better way to deal with them in this method.
+                }
             }
         }
         return out;

--- a/src/main/java/bot/utils/commands/AddCommand.java
+++ b/src/main/java/bot/utils/commands/AddCommand.java
@@ -40,7 +40,7 @@ class AddCommand extends Command {
      * @param ui      User interface for interacting with users.
      * @param storage Bot.Storage for storing data.
      * @return Bot's response to the command.
-     * @throws InvalidTaskException If the command creates a task and fails to do so.
+     * @throws InvalidTaskException If the command adds a task and fails to do so.
      */
     public String execute(TaskList tasks, Ui ui, Storage storage) throws InvalidTaskException {
         Task newTask = Task.makeTask(input);

--- a/src/main/java/bot/utils/commands/Command.java
+++ b/src/main/java/bot/utils/commands/Command.java
@@ -104,7 +104,7 @@ public abstract class Command {
      * @return Bot's response to the command.
      * @throws EmptyListException    If an illegal operation is performed on an empty list.
      * @throws InvalidIndexException If the command tries to access an invalid index.
-     * @throws InvalidTaskException  If the command creates a task and fails to do so.
+     * @throws InvalidTaskException  If the command adds a task and fails to do so.
      */
     public abstract String execute(TaskList tasks, Ui ui, Storage storage) throws EmptyListException,
             InvalidIndexException, InvalidTaskException;


### PR DESCRIPTION
Currently, the task list accepts duplicate tasks.

This is undesirable because it adds no additional information and clutters the list.

Enforcing uniqueness in the task list will allow us to reduce redundant information in the list.

Let's make TaskList contain only unique tasks.

We add an exception for the add method in TaskList as it's the easiest way to control uniqueness.